### PR TITLE
use preview domain

### DIFF
--- a/environment.sh
+++ b/environment.sh
@@ -1,4 +1,4 @@
 export SETTINGS='config.DevelopmentConfig'
-export PREMISES_REGISTER='http://premises.beta.openregister.org'
+export PREMISES_REGISTER='http://premises.preview.openregister.org'
 export MONGO_URI='mongodb://localhost:27017'
 export COMPANIES_HOUSE_API_KEY='not-real'


### PR DESCRIPTION
We're migrating from "beta" to "preview" in the domains to better
reflect the status of the server rather than the status of the project.
See also openregister/deployment#31
